### PR TITLE
Fixes nix standard derivation.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,19 +4,38 @@
 
 let
   zig-overlay = pkgs.fetchFromGitHub {
-    owner = "arqv";
+    owner = "mitchellh";
     repo = "zig-overlay";
-    rev = "5b9504b8bff072553051d6e130727f7f5c0715c3";
-    sha256 = "NDm5qT6/qr789IhI2dsQxrR5/Mr7cXVj17x/+tl3pDE=";
+    rev = "62ca03d2ff30fb2920c5a1d8a2b6c87d1b68867b";
+    sha256 = "1xriHeSpoL4qN5xqPiQc9S9R7Qvcl3RxHwJ5FYPjLn0=";
   };
+
   gitignoreSrc = pkgs.fetchFromGitHub {
     owner = "hercules-ci";
-    repo = "gitignore";
-    rev = "c4662e662462e7bf3c2a968483478a665d00e717";
-    sha256 = "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
+    repo = "gitignore.nix";
+    rev = "a20de23b925fd8264fd7fad6454652e142fd7f73";
+    sha256 = "8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=";
   };
+
   inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
-  zig = (import zig-overlay { inherit pkgs system; }).master.latest;
+  zig = (import zig-overlay { inherit pkgs system; }).master;
+
+  zon = builtins.fromJSON (
+    builtins.concatStringsSep "" [
+      "{"
+      (builtins.replaceStrings [ "}, " ] [ "}" ]
+        (builtins.replaceStrings [ " ." " =" "\n" ", }" ] [ "\"" "\" :" "" "}" ]
+          (builtins.replaceStrings [ ".{" ] [ "{" ]
+            (builtins.concatStringsSep " "
+              (builtins.filter builtins.isString
+                (builtins.split "[ \n]+"
+                  (builtins.elemAt
+                    (builtins.match ".*dependencies = .[{](.*)[}].*" (builtins.readFile ./build.zig.zon))
+                    0)))))))
+    ]
+  );
+
+  cp-phase = builtins.concatStringsSep ";" (builtins.attrValues (builtins.mapAttrs (k: v: "cp -r ${builtins.fetchTarball v.url} .cache/p/${v.hash}") zon));
 in
 pkgs.stdenvNoCC.mkDerivation {
   name = "zls";
@@ -27,7 +46,8 @@ pkgs.stdenvNoCC.mkDerivation {
   dontInstall = true;
   buildPhase = ''
     mkdir -p $out
-    zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master --prefix $out
+    mkdir -p .cache/{p,z,tmp}
+    ${cp-phase}
+    zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dcpu=baseline -Doptimize=ReleaseSafe -Ddata_version=master --prefix $out
   '';
-  XDG_CACHE_HOME = ".cache";
 }

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
         cp-phase = builtins.concatStringsSep ";" (builtins.attrValues (builtins.mapAttrs (k: v: "cp -r ${inputs.${k}} .cache/p/${v.hash}") zon));
       in
       rec {
+        formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
         packages.default = packages.zls;
         packages.zls = pkgs.stdenvNoCC.mkDerivation {
           name = "zls";


### PR DESCRIPTION
The standard derivation has been broken for quite some time now, but I didn't use it, so I didn't care to fix it. Today I cared. It now builds and is updated for the new packaging system.

I have a feeling this one will require less maintenance than the flake, as we only have to manually update the revision and hashes for zig and gitignore, and both should brake zls less often than its direct dependencies.